### PR TITLE
fix: Store Chart instance in ref and add cleanup to prevent memory leaks

### DIFF
--- a/src/app/components/BarChart/index.tsx
+++ b/src/app/components/BarChart/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 export interface BarChartProps {
   chartName: string;
@@ -8,12 +8,14 @@ export interface BarChartProps {
 }
 
 export default function BarChart({ chartName, className }: BarChartProps) {
+  const chartRef = useRef<any>(null);
+
   useEffect(() => {
     const init = async () => {
       const { initTE, Chart } = await import("tw-elements");
       initTE({ Chart });
       
-      new Chart(
+      chartRef.current = new Chart(
         document.getElementById(`bar-chart-${chartName}`), {
           type: 'bar',
           data: {
@@ -34,6 +36,12 @@ export default function BarChart({ chartName, className }: BarChartProps) {
     };
 
     init();
+
+    return () => {
+      if (chartRef.current) {
+        chartRef.current.destroy();
+      }
+    };
   }, [chartName]);
 
   const cn = `overflow-hidden ${className}`;


### PR DESCRIPTION
## Descrição
Este PR resolve a issue #1, onde o SonarCloud apontou uma instância do objeto Chart sendo criada sem ser armazenada ou utilizada, o que poderia levar a vazamentos de memória.

## Mudanças
- Adicionado `useRef` para armazenar a instância do Chart
- Implementado cleanup no `useEffect` para destruir o gráfico quando o componente é desmontado
- Melhorado o gerenciamento de memória do componente

## Testes
- [x] O gráfico continua funcionando normalmente
- [x] O SonarCloud não aciona mais o aviso de instância não utilizada
- [x] Não há vazamentos de memória ao desmontar o componente

## Screenshots
(Não aplicável para esta mudança)

## Checklist
- [x] O código segue os padrões do projeto
- [x] Os testes foram atualizados (se necessário)
- [x] A documentação foi atualizada (se necessário)
- [x] O PR está vinculado à issue #1

## Observações
Esta mudança melhora a qualidade do código e previne possíveis problemas de memória, seguindo as boas práticas de React para gerenciamento de recursos.

Closes #1